### PR TITLE
Update ds00_Upgrades.cfg

### DIFF
--- a/GameData/DeepSky/00DeepSky/00DeepSkyCRP/ds00_Upgrades.cfg
+++ b/GameData/DeepSky/00DeepSky/00DeepSkyCRP/ds00_Upgrades.cfg
@@ -45,7 +45,7 @@
 		HarvesterType = 2
 		Efficiency = 0.8
 		airSpeedStatic = 3000
-		ResourceName = Argon
+		ResourceName = ArgonGas
 		ConverterName = Argon Filter
 		StartActionName = Start Argon Filter
 		StopActionName = Stop Argon Filter
@@ -76,7 +76,7 @@
 		HarvesterType = 2
 		Efficiency = 0.4
 		airSpeedStatic = 3000
-		ResourceName = Xenon
+		ResourceName = XenonGas
 		ConverterName = Xenon Filter
 		StartActionName = Start Xenon Filter
 		StopActionName = Stop Xenon Filter


### PR DESCRIPTION
Resource harvester for intake was not working. Near Future Propulsion uses ArgonGas and XenonGas, not Argon and Xenon for ResourceName.